### PR TITLE
feat(infra): add shared lambda dependency layer

### DIFF
--- a/lambda-layers/shared-dependencies/package.json
+++ b/lambda-layers/shared-dependencies/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "shared-dependencies-layer",
+  "version": "1.0.0",
+  "description": "Shared dependencies layer for Lambda functions",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.883.0",
+    "@aws-sdk/lib-dynamodb": "^3.883.0",
+    "@clerk/backend": "^2.15.0",
+    "electrodb": "^3.4.5",
+    "pino": "^9.12.0",
+    "ulid": "^3.0.1"
+  }
+}

--- a/lib/constructs/lambda/lambda-factory.ts
+++ b/lib/constructs/lambda/lambda-factory.ts
@@ -1,5 +1,5 @@
 import { Duration } from 'aws-cdk-lib';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { ILayerVersion, Runtime } from 'aws-cdk-lib/aws-lambda';
 import {
   NodejsFunction,
   NodejsFunctionProps,
@@ -19,6 +19,7 @@ export class LambdaFactory {
   private readonly defaultEnvironment: Record<string, string>;
   private readonly defaultTimeout: Duration;
   private readonly defaultMemorySize: number;
+  private readonly sharedLayer: ILayerVersion;
 
   // Default configurations for Lambda functions
   private static readonly DEFAULT_TIMEOUT = Duration.seconds(30);
@@ -48,6 +49,7 @@ export class LambdaFactory {
 
     this.scope = scope;
     this.stageConfig = props.stageConfig;
+    this.sharedLayer = props.sharedLayer;
 
     // Set defaults with validation
     this.defaultEnvironment = this.validateEnvironmentVariables(
@@ -85,12 +87,13 @@ export class LambdaFactory {
       timeout: config.timeout || this.defaultTimeout,
       memorySize: config.memorySize || this.defaultMemorySize,
       environment,
+      layers: [this.sharedLayer],
       bundling: {
-        format: OutputFormat.CJS,
+        format: OutputFormat.ESM,
         target: 'node22',
         sourceMap: true,
         minify: this.stageConfig.config.isProduction,
-        externalModules: ['@aws-sdk/*'],
+        externalModules: ['@aws-sdk/*', '@clerk/*', 'electrodb', 'ulid'],
       },
     };
 

--- a/lib/constructs/layer/shared-dependencies-layer.ts
+++ b/lib/constructs/layer/shared-dependencies-layer.ts
@@ -1,0 +1,59 @@
+import { Code, LayerVersion, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
+import { StageConfiguration } from '../config/stage-config';
+
+export interface SharedDependenciesLayerProps {
+  /** Stage configuration for naming and environment-specific settings */
+  stageConfig: StageConfiguration;
+  /** Optional custom layer name (defaults to 'shared-dependencies') */
+  layerName?: string;
+  /** Optional description for the layer */
+  description?: string;
+}
+
+/**
+ * SharedDependenciesLayer provides a Lambda layer with common dependencies
+ * like ulid and dynamoose to reduce bundle sizes and improve cold start times.
+ */
+export class SharedDependenciesLayer extends Construct {
+  public readonly layer: LayerVersion;
+
+  constructor(scope: Construct, id: string, props: SharedDependenciesLayerProps) {
+    super(scope, id);
+
+    const layerName = props.stageConfig.getResourceName(
+      props.layerName || 'shared-dependencies'
+    );
+
+    const description = props.description ||
+      'Shared dependencies layer containing ulid and electrodb packages';
+
+    this.layer = new LayerVersion(this, 'Layer', {
+      layerVersionName: layerName,
+      description,
+      code: Code.fromAsset('lambda-layers/shared-dependencies', {
+        bundling: {
+          image: Runtime.NODEJS_22_X.bundlingImage,
+          command: [
+            'bash',
+            '-c',
+            [
+              'export HOME=/tmp',
+              'mkdir -p /tmp/bin',
+              'curl -fsSL https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linuxstatic-x64 -o /tmp/bin/pnpm',
+              'chmod +x /tmp/bin/pnpm',
+              'export PATH="/tmp/bin:$PATH"',
+              'mkdir -p /tmp/build',
+              'cp package.json /tmp/build/',
+              'cd /tmp/build',
+              'pnpm install --prod --no-lockfile --shamefully-hoist',
+              'mkdir -p /asset-output/nodejs',
+              'cp -r /tmp/build/node_modules /asset-output/nodejs/',
+            ].join(' && '),
+          ],
+        },
+      }),
+      compatibleRuntimes: [Runtime.NODEJS_22_X],
+    });
+  }
+}

--- a/lib/layer-stack.ts
+++ b/lib/layer-stack.ts
@@ -1,0 +1,38 @@
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { StageConfiguration } from './constructs/config/stage-config';
+import { SharedDependenciesLayer } from './constructs/layer/shared-dependencies-layer';
+import { StackConfiguration } from './types/infrastructure';
+
+export interface LayerStackProps extends StackProps {
+  /** Stack configuration including stage and project settings */
+  config?: StackConfiguration;
+}
+
+/**
+ * Stack for Lambda layers deployed alongside the main API stack
+ */
+export class LayerStack extends Stack {
+  public readonly sharedDependenciesLayer: SharedDependenciesLayer;
+
+  constructor(scope: Construct, id: string, props?: LayerStackProps) {
+    super(scope, id, props);
+
+    const config = props?.config || {};
+
+    // Create StageConfiguration
+    const stageConfig = new StageConfiguration({
+      stage: config.stage,
+      projectName: config.projectName,
+    });
+
+    // Create shared dependencies layer
+    this.sharedDependenciesLayer = new SharedDependenciesLayer(
+      this,
+      'SharedDependenciesLayer',
+      {
+        stageConfig,
+      }
+    );
+  }
+}

--- a/lib/types/infrastructure.ts
+++ b/lib/types/infrastructure.ts
@@ -1,6 +1,6 @@
 import type { Duration, RemovalPolicy } from 'aws-cdk-lib';
 import type { HttpMethod } from 'aws-cdk-lib/aws-apigatewayv2';
-import type { IFunction } from 'aws-cdk-lib/aws-lambda';
+import type { IFunction, ILayerVersion } from 'aws-cdk-lib/aws-lambda';
 import type { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import type { StageConfiguration } from '../constructs/config/stage-config';
 
@@ -100,6 +100,8 @@ export interface LambdaFactoryProps {
   defaultTimeout?: Duration;
   /** Default memory size for Lambda functions */
   defaultMemorySize?: number;
+  /** Shared Lambda layer for common dependencies */
+  readonly sharedLayer: ILayerVersion;
 }
 
 /**
@@ -145,4 +147,3 @@ export interface LambdaCreationConfig {
   environment?: Record<string, string>;
   tables?: TableAccess[];
 }
-

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
-    "deploy": "cdk deploy",
-    "deploy:dev": "cdk deploy -c stage=dev --require-approval never",
-    "deploy:prod": "cdk deploy -c stage=prod",
+    "deploy": "cdk deploy --all",
+    "deploy:dev": "cdk deploy --all -c stage=dev --require-approval never",
+    "deploy:prod": "cdk deploy --all -c stage=prod",
     "synth": "cdk synth",
     "synth:dev": "cdk synth -c stage=dev",
     "synth:prod": "cdk synth -c stage=prod",
@@ -22,20 +22,21 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.883.0",
     "@aws-sdk/lib-dynamodb": "^3.883.0",
+    "@clerk/backend": "^2.15.0",
+    "@types/aws-lambda": "^8.10.152",
     "@types/jest": "^29.5.14",
     "@types/node": "22.7.9",
     "aws-cdk": "2.1018.1",
+    "electrodb": "^3.4.5",
     "jest": "^29.7.0",
+    "pino": "^9.12.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.6.3"
   },
   "dependencies": {
-    "@clerk/backend": "^2.15.0",
-    "@types/aws-lambda": "^8.10.152",
     "aws-cdk-lib": "2.200.1",
     "constructs": "^10.0.0",
-    "electrodb": "^3.4.5",
     "esbuild": "^0.25.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.7.9)(ts-node@10.9.2(@types/node@22.7.9)(typescript@5.6.3))
+      pino:
+        specifier: ^9.12.0
+        version: 9.12.0
       ts-jest:
         specifier: ^29.2.5
         version: 29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(esbuild@0.25.9)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.7.9)(ts-node@10.9.2(@types/node@22.7.9)(typescript@5.6.3)))(typescript@5.6.3)
@@ -914,6 +917,10 @@ packages:
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   aws-cdk-lib@2.200.1:
     resolution: {integrity: sha512-kLeDtMJPYX3qSAGPONNa3XZk8Z/K3d0As8ui10/Hbv0ohsEsphxSy0xRoxdyj58/hGxOwj1TZsBezMp+TuPPrg==}
     engines: {node: '>= 14.15.0'}
@@ -1531,6 +1538,10 @@ packages:
   obliterator@1.6.1:
     resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -1580,6 +1591,16 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.0.0:
+    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
+
+  pino@9.12.0:
+    resolution: {integrity: sha512-0Gd0OezGvqtqMwgYxpL7P0pSHHzTJ0Lx992h+mNlMtRVfNnqweWmf0JmRWk5gJzHalyd2mxTzKjhiNbGS2Ztfw==}
+    hasBin: true
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -1592,6 +1613,9 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -1599,12 +1623,19 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -1626,6 +1657,10 @@ packages:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -1654,12 +1689,22 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  slow-redact@0.3.0:
+    resolution: {integrity: sha512-cf723wn9JeRIYP9tdtd86GuqoR5937u64Io+CYjlm2i7jvu7g0H+Cp0l0ShAf/4ZL+ISUTVT+8Qzz7RZmp9FjA==}
+
+  sonic-boom@4.2.0:
+    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
+
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
 
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -1721,6 +1766,9 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -3133,6 +3181,8 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
+  atomic-sleep@1.0.0: {}
+
   aws-cdk-lib@2.200.1(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.237
@@ -3919,6 +3969,8 @@ snapshots:
 
   obliterator@1.6.1: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -3960,6 +4012,26 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.0.0: {}
+
+  pino@9.12.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.0.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      slow-redact: 0.3.0
+      sonic-boom: 4.2.0
+      thread-stream: 3.1.0
+
   pirates@4.0.7: {}
 
   pkg-dir@4.2.0:
@@ -3972,6 +4044,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  process-warning@5.0.0: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -3979,9 +4053,13 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
+  quick-format-unescaped@4.0.4: {}
+
   react-is@18.3.1: {}
 
   react@19.1.1: {}
+
+  real-require@0.2.0: {}
 
   require-directory@2.1.1: {}
 
@@ -3999,6 +4077,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  safe-stable-stringify@2.5.0: {}
+
   semver@6.3.1: {}
 
   semver@7.7.2: {}
@@ -4015,12 +4095,20 @@ snapshots:
 
   slash@3.0.0: {}
 
+  slow-redact@0.3.0: {}
+
+  sonic-boom@4.2.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-support@0.5.13:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
 
@@ -4079,6 +4167,10 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   tmpl@1.0.5: {}
 


### PR DESCRIPTION
Introduces a new CDK LayerStack for common Lambda dependencies (AWS SDK, Clerk, ElectroDB, Pino, ULID). This reduces function bundle sizes and improves cold starts. LambdaFactory now consumes the layer, and the bundling process is updated to use pnpm and ESM. CDK deploy commands are updated to deploy all stacks.